### PR TITLE
Proposed minor change to get.offsets() function

### DIFF
--- a/R/helper.functions.R
+++ b/R/helper.functions.R
@@ -4,7 +4,7 @@ get.offsets <- function(data){
   
   header = names(data)
   
-  header = header[header != "datetime"] #Drop datetime
+  header = header[-grep(pattern= "datetime", x= header, ignore.case= TRUE)] #Drop datetime
   
   matches = regexpr("(\\d+\\.?\\d*)" ,header)
   


### PR DESCRIPTION
Eliminates case dependence for dropping "datetime" column.  If you get water temp data from a function like getTempGLMnc(), the first column header is "DateTime".  Then the first column isn't dropped because of case, and I get a dimension mismatch error when using some of the ts.xxx.xxx time series wrapper functions.  I see from the documentation that wtr is intended to be loaded with load.ts(), but I thought this might still be helpful.
