### PR TITLE
updated ts.schmidt.stability to handle NA's better

### DIFF
--- a/R/timeseries.functions.R
+++ b/R/timeseries.functions.R
@@ -67,7 +67,7 @@ ts.schmidt.stability <- function(wtr, bathy, na.rm=FALSE){
 	for(i in 1:n){
     if(na.rm){
       temps = wtr.mat[i,]
-      if(all(is.na(temps)){
+      if(all(is.na(temps))){
       	next
       }
       notNA = !is.na(temps)


### PR DESCRIPTION
Skipping over rows in which there are NA's for all water temperature depths; running schmidt.stability() on rows with all NA's throws an error.
